### PR TITLE
Failing model inheritance test.

### DIFF
--- a/testapp/models.py
+++ b/testapp/models.py
@@ -60,3 +60,6 @@ class EstrangedChild(models.Model):
 class PsychoChild(models.Model):
     name = models.CharField(max_length=16)
     alter_egos = models.ManyToManyField("self")
+
+class AdoptedChild(Child):
+    birth_origin = models.CharField(max_length=100)

--- a/testapp/tests.py
+++ b/testapp/tests.py
@@ -72,6 +72,17 @@ class ModelTest(unittest.TestCase):
         self.assertEquals(child.alter_egos.all().count(), 1)
         self.assertEquals(PsychoChild.objects.all().count(), 2)
 
+INHERITED_MODELS = [AdoptedChild]
+class ModelInheritanceTest(unittest.TestCase):
+    def tearDown(self):
+        for m in INHERITED_MODELS:
+            m._default_manager.all().delete()
+    
+    def test_create_adopted_child(self):
+        from ipdb import set_trace; set_trace()
+        a = milkman.deliver(AdoptedChild)
+        assert a.child is not None
+
 class RandomFieldTest(unittest.TestCase):
     def test_required_field(self):
         root = milkman.deliver(Root)

--- a/testapp/tests.py
+++ b/testapp/tests.py
@@ -79,7 +79,6 @@ class ModelInheritanceTest(unittest.TestCase):
             m._default_manager.all().delete()
     
     def test_create_adopted_child(self):
-        from ipdb import set_trace; set_trace()
         a = milkman.deliver(AdoptedChild)
         assert a.child is not None
 


### PR DESCRIPTION
As you can see when running the test it throws an IntegrityError because root object isn't saved.
