### PR TITLE
Add support for specifying fields on related models

### DIFF
--- a/testapp/tests.py
+++ b/testapp/tests.py
@@ -72,6 +72,25 @@ class ModelTest(unittest.TestCase):
         self.assertEquals(child.alter_egos.all().count(), 1)
         self.assertEquals(PsychoChild.objects.all().count(), 2)
 
+    def test_related_explicit_values(self):
+        child = milkman.deliver(Child, root__my_char='foo')
+        self.assertEqual(child.root.my_char, 'foo')
+
+        grandchild = milkman.deliver(GrandChild, parent__name='foo', parent__root__my_char='bar')
+        self.assertEqual(grandchild.parent.name, 'foo')
+        self.assertEqual(grandchild.parent.root.my_char, 'bar')
+
+        root = milkman.deliver(Root)
+        grandchild = milkman.deliver(GrandChild, parent__root=root)
+        self.assertEqual(root.pk, grandchild.parent.root.pk)
+
+    def test_m2m_related_explicit_values(self):
+        aunt = milkman.deliver(Aunt, uncles__name='foo')
+        self.assertEqual(1, len(aunt.uncles.all()))
+        self.assertEqual(aunt.uncles.all()[0].name, 'foo')
+
+
+
 INHERITED_MODELS = [AdoptedChild]
 class ModelInheritanceTest(unittest.TestCase):
     def tearDown(self):


### PR DESCRIPTION
Add support for specifying field values on related models using double underscore notation

This allows you to build deeply nested object trees very easily, while overriding the values of a few fields that Milkman would otherwise generate for you. It uses the same double underscore syntax the ORM uses to filter across relations. Examples (taken from the tests):

```
child = milkman.deliver(Child, root__my_char='foo')
self.assertEqual(child.root.my_char, 'foo')

grandchild = milkman.deliver(GrandChild, parent__name='foo', parent__root__my_char='bar')
self.assertEqual(grandchild.parent.name, 'foo')
self.assertEqual(grandchild.parent.root.my_char, 'bar')
```

With many-to-many relations, Milkman will automatically generate a single related object, so the field values will be set on this:

```
aunt = milkman.deliver(Aunt, uncles__name='foo')
self.assertEqual(1, len(aunt.uncles.all()))
self.assertEqual(aunt.uncles.all()[0].name, 'foo')
```

I haven't added any docs, as it looks like the documentation is pretty minimal anyway (I'm assuming you're expecting people to read the tests to get a feel for the API). Let me know if you want me to add anything to the docs.
