### PR TITLE
Update milkman/dairy.py

### DIFF
--- a/milkman/dairy.py
+++ b/milkman/dairy.py
@@ -120,7 +120,10 @@ class MilkTruck(object):
     def set_explicit_values(self, target, explicit_values):
         for k, v in explicit_values.iteritems():
             if not self.is_m2m(k):
-                setattr(target, k, v)
+                try:
+                    setattr(target, k, v)
+                except:
+                    target.k = v
 
     def set_m2m_explicit_values(self, target, explicit_values):
         for k, vs in explicit_values.iteritems():
@@ -135,7 +138,8 @@ class MilkTruck(object):
                 v = the_milkman.deliver(field.rel.to, **explicit_values)
             else:
                 v = self.generator_for(the_milkman.registry, field).next()
-            setattr(target, field.name, v)
+            if not getattr(target, field.name):
+                setattr(target, field.name, v)
 
     def set_m2m_fields(self, target, the_milkman, exclude, related_explicit_values):
         for field in self.fields_to_generate(


### PR DESCRIPTION
When using the django-polymorphic app via django-shop, I end up with my product, let's say a Video, that inherits from Product.

When I try to milkman.deliver(Video), I get the error: "can't set attribute" (would be nice to get more info about that attribute that couldn't be set btw).
Trying with milkman.deliver(Video, product=product_previously_delivered) or with milkman.deliver(Video, product_ptr=product) doesn't help.

That is explained because :
- the field doesn't exists when it's trying to set the value in explicit_values, therefore setattr fails.
- the field already exists in read-only for set_local_fields, so setattr fails as well.

That's why I came with those solution:
- for set_local_fields, insure that the field doesn't already exist
- for the explicit value, if setattr fail, hardcode the field with target.k

If you have any issues with those solutions, thanks for explaining the reasons and offering a better solution to solve that problem, thanks in advance !
