### PR TITLE
Support Django 1.6b4, support Oracle, fix the test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ runtests
 .venv
 /build
 /dist
+/testapp/uploads
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *.DS_Store
 runtests
 .venv
+/build
+/dist
+/testapp/uploads

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *.DS_Store
 runtests
 .venv
+/build
+/dist
+

--- a/milkman/dairy.py
+++ b/milkman/dairy.py
@@ -182,10 +182,19 @@ class MilkTruck(object):
                 self.needs_generated_value(f)]
 
     def needs_generated_value(self, field):
-        return hasattr(field, 'has_default') and \
-               not field.has_default() and \
-               not field.blank and \
-               not field.null
+        # no need to generate if the field has a default value
+        has_default = hasattr(field, 'has_default') and field.has_default()
+        if has_default:
+            return False
+
+        # In Oracle, any CharField descendant will be nullable.
+        # In other databases, no CharField descendant will be nullable.
+        # We can use blank as the arbiter of requiredness for CharFields.
+        if isinstance(field, models.CharField):
+            return not field.blank
+        else:
+            # generate if both blank and null are False
+            return not field.blank and not field.null
 
 
 class Milkman(object):

--- a/milkman/dairy.py
+++ b/milkman/dairy.py
@@ -187,14 +187,21 @@ class MilkTruck(object):
         if has_default:
             return False
 
+        # in Django 1.6, BooleanField() is null=False and blank=True
+        # even though, on syncdb, it is created as not null.
+        if isinstance(field, models.BooleanField):
+            return not field.null or not field.blank
         # In Oracle, any CharField descendant will be nullable.
         # In other databases, no CharField descendant will be nullable.
         # We can use blank as the arbiter of requiredness for CharFields.
         # Oracle doesn't care if you put null=False on a ManyToManyField
         # the resulting field will be nullable.
-        if isinstance(field, models.CharField)\
-                or isinstance(field, models.FileField)\
-                or isinstance(field, models.ManyToManyField):
+        gen_if_not_blank_classes = (
+            models.CharField,
+            models.FileField,
+            models.ManyToManyField,
+        )
+        if isinstance(field, gen_if_not_blank_classes):
             return not field.blank
         else:
             # generate if both blank and null are False

--- a/milkman/dairy.py
+++ b/milkman/dairy.py
@@ -190,8 +190,11 @@ class MilkTruck(object):
         # In Oracle, any CharField descendant will be nullable.
         # In other databases, no CharField descendant will be nullable.
         # We can use blank as the arbiter of requiredness for CharFields.
+        # Oracle doesn't care if you put null=False on a ManyToManyField
+        # the resulting field will be nullable.
         if isinstance(field, models.CharField)\
-                or isinstance(field, models.FileField):
+                or isinstance(field, models.FileField)\
+                or isinstance(field, models.ManyToManyField):
             return not field.blank
         else:
             # generate if both blank and null are False

--- a/milkman/dairy.py
+++ b/milkman/dairy.py
@@ -190,7 +190,8 @@ class MilkTruck(object):
         # In Oracle, any CharField descendant will be nullable.
         # In other databases, no CharField descendant will be nullable.
         # We can use blank as the arbiter of requiredness for CharFields.
-        if isinstance(field, models.CharField):
+        if isinstance(field, models.CharField)\
+                or isinstance(field, models.FileField):
             return not field.blank
         else:
             # generate if both blank and null are False

--- a/milkman/generators.py
+++ b/milkman/generators.py
@@ -146,7 +146,7 @@ def random_auto_field_maker(field):
 
 
 def random_float():
-    return random.uniform(sys.float_info.min, sys.float_info.max)
+    return random.uniform(-1e10, 1e10)
 
 
 def random_ipaddress_maker(field):

--- a/testapp/manage.py
+++ b/testapp/manage.py
@@ -1,14 +1,10 @@
 #!/usr/bin/env python
+import os
 import sys
-from django.core.management import execute_manager
+from django.core.management import execute_from_command_line
 
 sys.path.append('../')
-try:
-    from testapp import settings 
-except ImportError:
-    import sys
-    sys.stderr.write("Error: Can't find the file 'settings.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)
-    sys.exit(1)
 
 if __name__ == "__main__":
-    execute_manager(settings)
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "testapp.settings")
+    execute_from_command_line(sys.argv)

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -10,3 +10,5 @@ ROOT_URLCONF = ''
 INSTALLED_APPS = (
     'testapp',
 )
+SECRET_KEY = 'foobar'
+

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -10,3 +10,4 @@ ROOT_URLCONF = ''
 INSTALLED_APPS = (
     'testapp',
 )
+SECRET_KEY = 'bla'

--- a/testapp/tests.py
+++ b/testapp/tests.py
@@ -1,3 +1,4 @@
+import datetime
 import unittest
 import types
 import sys
@@ -128,7 +129,7 @@ class RandomFieldTest(unittest.TestCase):
         assert isinstance(root.my_char, str)
         assert isinstance(root.my_commaseperatedinteger, str)
         assert isinstance(root.my_date, str)
-        assert isinstance(root.my_datetime, str)
+        assert isinstance(root.my_datetime, datetime.datetime)
         assert isinstance(root.my_decimal, str)
         assert isinstance(root.my_email, str)
         assert isinstance(root.my_float, float)

--- a/testapp/tests.py
+++ b/testapp/tests.py
@@ -164,9 +164,10 @@ class FieldValueGeneratorTest(unittest.TestCase):
         self.assertEqual([1, 1], [s for s in random_choice_iterator([1], 2)])
         
     def test_random_float(self):
-        assert random_float() >= sys.float_info.min
-        assert random_float() <= sys.float_info.max
-        assert isinstance(random_float(), float)
+        f = random_float()
+        self.assert_(f >= -1e10)
+        self.assert_(f <= 1e10)
+        self.assert_(isinstance(f, float))
         
     def test_random_ipaddress(self):
         f = models.IPAddressField()

--- a/testapp/tests.py
+++ b/testapp/tests.py
@@ -115,7 +115,11 @@ class ModelInheritanceTest(unittest.TestCase):
 class RandomFieldTest(unittest.TestCase):
     def test_required_field(self):
         root = milkman.deliver(Root)
-        assert isinstance(root.my_auto, int)
+        a = root.my_auto
+        self.assert_(
+            isinstance(a, int)
+            or isinstance(a, long)
+        )
         try:
             assert isinstance(root.my_biginteger, type(models.BigIntegerField.MAX_BIGINT))
         except AttributeError:


### PR DESCRIPTION
This makes the milkman tests pass against Oracle. It also makes it possible to run tests using milkman against Oracle in a large codebase.
