### PR TITLE
Fixes pip install (#30).

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include docs/index.txt

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ Quick Examples
 
 	from milkman.dairy import milkman
 	from myapp.models import Video, Editor
-	
+
 	#I just want a random video in the db to test with
 	v = milkman.deliver(Video)
-	
+
 	#I want a video with a particular editor
 	e = milkman.deliver(Editor)
 	v = milkman.deliver(Video, editor=e)
-	
-	
+
+
 Development
 -----------
 Install virtualenv and virtualenvwrapper
@@ -32,7 +32,11 @@ Running Tests
 
     cd testapp
     ./manage.py test
-  
+
+In addition you can install [the tox testing tool](http://tox.testrun.org/) to quickly run the tests against multiple installed versions of Python and Django.
+
+Once tox has been installed you can run tests from the source directory with `tox`. This will build virtual environments for the versions defined in the file tox.ini and then install and test the source in each.
+
 
 Known Issues
 ------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 django
 docutils>=0.3
-PIL
+Pillow

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,10 @@
 import os
 import sys
-from setuptools import setup, find_packages
+from setuptools import setup
 
 milkman = __import__("milkman")
-readme_file = os.path.join(os.path.dirname(__file__), "docs/index.txt")
-try:
-    long_description = open(readme_file).read()
-except IOError as err:
-    sys.stderr.write("[ERROR] Cannot find file specified as "
-        "``long_description`` (%s)\n" % readme_file)
-    sys.exit(1)
+readme_file = os.path.join(os.path.dirname(__file__), 'docs', 'index.txt')
+long_description = open(readme_file).read()
 
 if sys.version_info >= (3,):
     extra_kwargs = {"use_2to3": True}
@@ -23,11 +18,10 @@ setup(
     long_description=long_description,
     author="Wilkes Joiner, Chuck Collins, Patrick Altman",
     author_email="chuck.collins@gmail.com",
-    license="BSD",
+    license="MIT",
     url="http://github.com/ccollins/milkman/",
     keywords="django testing mock stub",
-    packages=find_packages(exclude=["tests.*", "tests"]),
-    include_package_data=True,
+    packages=['milkman'],
     install_requires=[
         "docutils>=0.3",
     ],

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -10,3 +10,5 @@ ROOT_URLCONF = ''
 INSTALLED_APPS = (
     'testapp',
 )
+
+SECRET_KEY = 'dummykeyfortesting'

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist = py27-django16,py33-django16
+
+[testenv]
+commands = django-admin.py test testapp --settings=testapp.settings
+
+[testenv:py27-django16]
+basepython = python2.7
+deps =
+    django<1.7
+    Pillow
+
+[testenv:py33-django16]
+basepython = python3.3
+deps =
+    django<1.7
+    Pillow


### PR DESCRIPTION
- Simplify setup.py and change license name to MIT.
- Adds docs/index.txt to distribution, removes .egg-info package.
- Adds support for running tests with tox.
- Fixes test settings.py so tests can run (but still lots of failures).
- Replace PIL with Pillow in requirements.txt.
